### PR TITLE
Provide an option to remove the id

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -8,6 +8,7 @@ def main(argv):
     output = ''
     outtype = ''
     norm = 0
+    print_id = True
     helpText = "convert.py -i <inputfile> -o <outputfile> -t <type>\n"
     if len(sys.argv) <= 4:
         print(helpText)
@@ -15,7 +16,7 @@ def main(argv):
 
     try:
         opts, args = getopt.getopt(
-            argv, "hi:o:t:n:", ["ifile=", "ofile="])
+            argv, "hi:o:t:n:d:", ["ifile=", "ofile="])
     except getopt.GetoptError:
         print(helpText)
         sys.exit(0)
@@ -31,10 +32,12 @@ def main(argv):
         elif opt in ("-t", "--type"):
             outtype = arg
         elif opt in ("-n", "--normalize"):
-            norm = int(arg) 
+            norm = int(arg)
+        elif opt in ("-d", "`--print_id"):
+            print_id = int(arg)
                
                
-    mesh.GmshToParticles(outtype, path, output,norm)
+    mesh.GmshToParticles(outtype, path, output, print_id, norm)
 
 if __name__ == "__main__":
     main(sys.argv[1:])    

--- a/gmshtoparticles/mesh.py
+++ b/gmshtoparticles/mesh.py
@@ -68,13 +68,15 @@ class GmshToParticles():
         with open(outFile, "w") as file:
             file.write("#id x y vol\n")
             i = 0
-            for node in self.cells['triangle']:
-                area = self.areaTriangle(node)
-                center = self.centerTriangle(node)
-                line = "{:d}, {:.2e}, {:.2e}, {:.2e}".format(i ,center[0], center[1], area )
-                file.write(line + os.linesep)
-                i += 1
-            file.close()
+            for cell in self.cells:
+                if cell.type == "triangle":
+                    for node in self.cells['triangle']:
+                        area = self.areaTriangle(node)
+                        center = self.centerTriangle(node)
+                        line = "{:d}, {:.2e}, {:.2e}, {:.2e}".format(i ,center[0], center[1], area )
+                        file.write(line + os.linesep)
+                        i += 1
+                file.close()
             
     #For now renamed function textfile_square
     def textFile_square(self, outFile):

--- a/gmshtoparticles/mesh.py
+++ b/gmshtoparticles/mesh.py
@@ -73,7 +73,7 @@ class GmshToParticles():
             i = 0
             for cell in self.cells:
                 if cell.type == "triangle":
-                    for node in self.cells['triangle']:
+                    for node in cell.data:
                         area = self.areaTriangle(node)
                         center = self.centerTriangle(node)
                         if print_id:
@@ -82,7 +82,7 @@ class GmshToParticles():
                             line = "{:.2e}, {:.2e}, {:.2e}".format(center[0], center[1], area )
                         file.write(line + os.linesep)
                         i += 1
-                file.close()
+            file.close()
             
     #For now renamed function textfile_square
     def textFile_square(self, outFile, print_id):
@@ -130,7 +130,7 @@ class GmshToParticles():
         if type_ == "triangle":
             for i in range (0,len(nodes)):
                 center = self.centerTriangle(nodes[i])
-                area = self.areaTriangle(node[i])
+                area = self.areaTriangle(nodes[i])
                 points.InsertPoint(i,center[0],center[1],0)
                 array.SetTuple1(i,area)
         elif type_ == "quad":

--- a/gmshtoparticles/mesh.py
+++ b/gmshtoparticles/mesh.py
@@ -10,7 +10,7 @@ import vtk
 
 class GmshToParticles():
     
-    def __init__(self, element_type = 'triangle', mesh_input = 'input.msh', output = 'output',norm=0):
+    def __init__(self, element_type = 'triangle', mesh_input = 'input.msh', output = 'output', print_id = True, norm=0):
         mesh = meshio.read(mesh_input)
         self.points = mesh.points
         self.cells = mesh.cells
@@ -25,11 +25,11 @@ class GmshToParticles():
         
         if element_type == "triangle":
             csv_output = output + ".csv"
-            self.textFile_triangle(csv_output)
+            self.textFile_triangle(csv_output, print_id)
             print(".csv output file written at", csv_output)  
         elif element_type == "quad":
             csv_output = output + ".csv"
-            self.textFile_square(csv_output)
+            self.textFile_square(csv_output, print_id)
             print (".csv output file written at", csv_output)  
         else:
             print ("Supported element_type are triangle or quad")
@@ -64,31 +64,43 @@ class GmshToParticles():
         return np.linalg.norm(a*b)
     
     #For now renamed function textfile_triangle
-    def textFile_triangle(self, outFile):
+    def textFile_triangle(self, outFile, print_id):
         with open(outFile, "w") as file:
-            file.write("#id x y vol\n")
+            if print_id:
+                file.write("#id x y vol\n")
+            else:
+                file.write("#x y vol\n")
             i = 0
             for cell in self.cells:
                 if cell.type == "triangle":
                     for node in self.cells['triangle']:
                         area = self.areaTriangle(node)
                         center = self.centerTriangle(node)
-                        line = "{:d}, {:.2e}, {:.2e}, {:.2e}".format(i ,center[0], center[1], area )
+                        if print_id:
+                            line = "{:d}, {:.2e}, {:.2e}, {:.2e}".format(i ,center[0], center[1], area )
+                        else:
+                            line = "{:.2e}, {:.2e}, {:.2e}".format(center[0], center[1], area )
                         file.write(line + os.linesep)
                         i += 1
                 file.close()
             
     #For now renamed function textfile_square
-    def textFile_square(self, outFile):
+    def textFile_square(self, outFile, print_id):
         with open(outFile, "w") as file:
-            file.write("#id x y vol\n")
+            if print_id:
+                file.write("#id x y vol\n")
+            else:
+                file.write("#x y vol\n")
             i = 0
             for cell in self.cells:
                 if cell.type == "quad":
                     for node in cell.data:
                         area = self.areaSquare(node)
                         center = self.centerSquare(node)
-                        line = "{:d}, {:.2e}, {:.2e}, {:.2e}".format(i ,center[0], center[1], area )
+                        if print_id:
+                            line = "{:d}, {:.2e}, {:.2e}, {:.2e}".format(i ,center[0], center[1], area )
+                        else:
+                            line = "{:.2e}, {:.2e}, {:.2e}".format(center[0], center[1], area )
                         file.write(line + os.linesep)
                         i += 1
             file.close()

--- a/gmshtoparticles/mesh.py
+++ b/gmshtoparticles/mesh.py
@@ -81,39 +81,48 @@ class GmshToParticles():
         with open(outFile, "w") as file:
             file.write("#id x y vol\n")
             i = 0
-            for node in self.cells['quad']:
-                area = self.areaSquare(node)
-                center = self.centerSquare(node)
-                line = "{:d}, {:.2e}, {:.2e}, {:.2e}".format(i ,center[0], center[1], area )
-                file.write(line + os.linesep)
-                i += 1
+            for cell in self.cells:
+                if cell.type == "quad":
+                    for node in cell.data:
+                        area = self.areaSquare(node)
+                        center = self.centerSquare(node)
+                        line = "{:d}, {:.2e}, {:.2e}, {:.2e}".format(i ,center[0], center[1], area )
+                        file.write(line + os.linesep)
+                        i += 1
             file.close()
     
     #needs to be rewritten for square and triangle
     def vtkFile(self, outFile, type_ ):
+        number = 0
+        nodes = []
+        for cell in self.cells:
+            if cell.type == type_:
+                number = len(cell.data)
+                nodes = cell.data 
+
         writer = vtk.vtkXMLUnstructuredGridWriter()
         writer.SetFileName(outFile)
         grid = vtk.vtkUnstructuredGrid()
         points = vtk.vtkPoints()
-        points.SetNumberOfPoints(len(self.cells[type_]))
+        points.SetNumberOfPoints(number)
         points.SetDataTypeToDouble()
         dataOut = grid.GetPointData()
        
         array = vtk.vtkDoubleArray()
         array.SetName("Volume")
         array.SetNumberOfComponents(1)
-        array.SetNumberOfTuples(len(self.cells[type_]))
+        array.SetNumberOfTuples(number)
        
         if type_ == "triangle":
-            for i in range (0,len(self.cells[type_])):
-                center = self.centerTriangle(self.cells[type_][i])
-                area = self.areaTriangle(self.cells[type_][i])
+            for i in range (0,len(nodes)):
+                center = self.centerTriangle(nodes[i])
+                area = self.areaTriangle(node[i])
                 points.InsertPoint(i,center[0],center[1],0)
                 array.SetTuple1(i,area)
         elif type_ == "quad":
-            for i in range (0,len(self.cells[type_])):
-                center = self.centerSquare(self.cells[type_][i])
-                area = self.areaSquare(self.cells[type_][i])
+            for i in range (0,len(nodes)):
+                center = self.centerSquare(nodes[i])
+                area = self.areaSquare(nodes[i])
                 points.InsertPoint(i,center[0],center[1],0)
                 array.SetTuple1(i,area)
 


### PR DESCRIPTION
For some codes, the id is needed in the CSV file, and for some not.

Now we have the option `-d` or `--print_id` to decide if the id is added or not.